### PR TITLE
Stick bevy_matchbox to version 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ bevy_asset_loader = "0.17"
 bevy = "0.11"
 bytemuck = {version="1.7.3", features= ["derive"]}
 bevy_ggrs = "0.13"
-bevy_matchbox = { git="https://github.com/johanhelsing/matchbox", features = ["ggrs"] }
+bevy_matchbox = { version="0.7.0", features = ["ggrs"] }
 log = "0.4"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
It seems bevy_matchbox got an 0.8 version recently. It breaks building the demo with the error:
the trait bound `bevy_matchbox::MatchboxSocket<bevy_matchbox::prelude::SingleChannel>: bevy::prelude::Resource` is not satisfied Using bevy_matchbox 0.7 fix the issue.